### PR TITLE
Fix for #4 Consumes food after activation

### DIFF
--- a/src/main/java/org/terasology/hunger/HungerAuthoritySystem.java
+++ b/src/main/java/org/terasology/hunger/HungerAuthoritySystem.java
@@ -146,6 +146,11 @@ public class HungerAuthoritySystem extends BaseComponentSystem implements Update
         }
     }
 
+    /**
+     * This method deals with removal of food item after it is consumed.
+     * @param event The FoodConsumedEvent called when an entity consumes food.
+     * @param item The entity which is consuming the food.
+     */
     @ReceiveEvent(components = ItemComponent.class, priority = EventPriority.PRIORITY_TRIVIAL)
     public void usedItem(FoodConsumedEvent event, EntityRef item) {
         ItemComponent itemComp = item.getComponent(ItemComponent.class);

--- a/src/main/java/org/terasology/hunger/event/FoodConsumedEvent.java
+++ b/src/main/java/org/terasology/hunger/event/FoodConsumedEvent.java
@@ -19,6 +19,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.logic.common.ActivateEvent;
 
+/** This event is triggered after the Activate event has been consumed upon eating of a food item */
 public class FoodConsumedEvent implements Event {
     private EntityRef instigator;
     private EntityRef target;

--- a/src/main/java/org/terasology/hunger/event/FoodConsumedEvent.java
+++ b/src/main/java/org/terasology/hunger/event/FoodConsumedEvent.java
@@ -15,7 +15,24 @@
  */
 package org.terasology.hunger.event;
 
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.logic.common.ActivateEvent;
 
 public class FoodConsumedEvent implements Event {
+    private EntityRef instigator;
+    private EntityRef target;
+
+    public FoodConsumedEvent(ActivateEvent event) {
+        this.instigator = event.getInstigator();
+        this.target = event.getTarget();
+    }
+
+    public EntityRef getInstigator() {
+        return instigator;
+    }
+
+    public EntityRef getTarget() {
+        return target;
+    }
 }


### PR DESCRIPTION
Fix for issue #4 

To test:

- Activate cooking and hunger
- console `give applePie`
- console `hungerSet 10`
- Select applePie and right click to eat

Do the above before and after applying the patch.

--
The fix uses the newly created event- FoodConsumedEvent, to handle removal of the food item from inventory instead of relying on the ItemAuthoritySystem to use the ActivateEvent (that already gets consumed by the HungerAuthoritySystem) with a low priority.

Can you test and confirm this method? @oniatus @Josharias @Cervator 