### PR TITLE
Changed FoodComponent.filling to ModifiableValue

### DIFF
--- a/src/main/java/org/terasology/hunger/HungerAuthoritySystem.java
+++ b/src/main/java/org/terasology/hunger/HungerAuthoritySystem.java
@@ -185,7 +185,7 @@ public class HungerAuthoritySystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void foodConsumed(ActivateEvent event, EntityRef item, FoodComponent food) {
-        float filling = food.filling;
+        float filling = food.filling.getValue();
         EntityRef instigator = event.getInstigator();
         HungerComponent hunger = instigator.getComponent(HungerComponent.class);
         if (hunger != null) {

--- a/src/main/java/org/terasology/hunger/component/FoodComponent.java
+++ b/src/main/java/org/terasology/hunger/component/FoodComponent.java
@@ -16,11 +16,18 @@
 package org.terasology.hunger.component;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.logic.inventory.ItemDifferentiating;
+import org.terasology.utilities.modifiable.ModifiableValue;
 
-public class FoodComponent implements Component {
+
+/**
+ * This component uses the ModifiableValue type
+ * Any modifications to the data members of this component must be via ModifiableValue modifiers
+ * ModifiableValue.getValue can be used to get the value of the data members
+ */
+public class FoodComponent implements Component, ItemDifferentiating {
     /**
      * The amount of hunger this food restores when used.
      */
-    public float filling;
-
+    public ModifiableValue filling;
 }

--- a/src/main/java/org/terasology/hunger/component/FoodComponent.java
+++ b/src/main/java/org/terasology/hunger/component/FoodComponent.java
@@ -25,7 +25,7 @@ import org.terasology.utilities.modifiable.ModifiableValue;
  * Any modifications to the data members of this component must be via ModifiableValue modifiers
  * ModifiableValue.getValue can be used to get the value of the data members
  */
-public class FoodComponent implements Component, ItemDifferentiating {
+public class FoodComponent implements Component{
     /**
      * The amount of hunger this food restores when used.
      */

--- a/src/main/java/org/terasology/hunger/system/GenomeModifierSystem.java
+++ b/src/main/java/org/terasology/hunger/system/GenomeModifierSystem.java
@@ -1,0 +1,4 @@
+package org.terasology.hunger.system;
+
+public class GenomeModifierSystem {
+}

--- a/src/main/java/org/terasology/hunger/system/GenomeModifierSystem.java
+++ b/src/main/java/org/terasology/hunger/system/GenomeModifierSystem.java
@@ -1,4 +1,0 @@
-package org.terasology.hunger.system;
-
-public class GenomeModifierSystem {
-}


### PR DESCRIPTION
Changed the FoodComponent to use the ModifiableValue type for the filling. The filling value can now be modified by other content modules correctly and the value can be used via the getValue function.

To test this PR, https://github.com/MovingBlocks/Terasology/pull/4094 is required in your workspace as the ModifiableValue type is used in this PR.

To-do before merging : 
- [x] Change the filling usage in EdibleSubstance to match ModifiableValue syntax
- [x] Re Run jenkins tests once ModifiableValue is merged.