### PR TITLE
fix: move breathing bar above hunger bar when Hunger is active

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -12,6 +12,10 @@
         {
             "id": "Inventory",
             "minVersion": "1.1.0"
+        },
+        {
+            "id": "Breathing",
+            "optional": true
         }
     ],
     "isLibrary": true,

--- a/overrides/Breathing/ui/Breathing.ui
+++ b/overrides/Breathing/ui/Breathing.ui
@@ -1,0 +1,28 @@
+{
+  "type": "BreathingBar",
+  "skin": "HUD",
+  "contents": {
+    "type": "relativeLayout",
+    "contents": [
+      {
+        "type": "UIIconBar",
+        "id": "breathBar",
+        "icon": "CoreAssets:icons#bubble",
+        "family": "breathBar",
+        "emptyIcon": "CoreAssets:icons#burstBubble",
+        "halfIconMode": "shrink",
+        "spacing": 2,
+        "maxIcons": 10,
+        "layoutInfo": {
+          "use-content-width": true,
+          "use-content-height": true,
+          "position-horizontal-center": {},
+          "position-bottom": {
+            "target": "BOTTOM",
+            "offset": 102
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
added Breathing as optional dependency and created an override on Breathing bar position so it doesn't collide with Hunger bar.